### PR TITLE
Add various improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,22 +39,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -169,12 +169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-cstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,9 +192,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -222,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "19.2.0"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation",
  "core-graphics",
@@ -283,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
@@ -330,24 +324,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -406,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "float-ord"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fnv"
@@ -418,19 +412,19 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-kit"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fe28504d371085fae9ac7a3450f0b289ab71e07c8e57baa3fb68b9e57d6ce5"
+checksum = "b64b34f4efd515f905952d91bc185039863705592c0c53ae6d979805dd154520"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "byteorder",
  "core-foundation",
  "core-graphics",
  "core-text",
- "dirs-next",
+ "dirs",
  "dwrote",
  "float-ord",
- "freetype",
+ "freetype-sys",
  "lazy_static",
  "libc",
  "log",
@@ -443,34 +437,36 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "freetype"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc8599a3078adf8edeb86c71e9f8fa7d88af5ca31e806a867756081f90f5d83"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "freetype-sys",
- "libc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
-name = "freetype-sys"
-version = "0.19.0"
+name = "foreign-types-shared"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ee28c39a43d89fbed8b4798fb4ba56722cfd2b5af81f9326c27614ba88ecd5"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
 dependencies = [
  "cc",
  "libc",
@@ -549,12 +545,27 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -599,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -617,8 +628,9 @@ dependencies = [
 name = "link_scraper"
 version = "0.1.4"
 dependencies = [
+ "cfg-if",
  "infer",
- "itertools",
+ "itertools 0.13.0",
  "kamadak-exif",
  "linkify",
  "mupdf",
@@ -682,22 +694,24 @@ dependencies = [
 
 [[package]]
 name = "mupdf"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14660d0f9bab7127acf203e5690b8dffc91b696e2db901d28ed35f76478fa967"
+checksum = "7e286545311485e9468840b81b9014f4164ab16b071a53fa755536d52f43b915"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "font-kit",
  "mupdf-sys",
  "num_enum",
  "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "mupdf-sys"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a3d545b8917d0ed22faed09c1a0492d4e87a68c046fac8e0bffec1cf3428b3"
+checksum = "bd2bd5de0f9c7ab0da37de2299626b8449a1263304f8a54def2a93ddfe31ee9b"
 dependencies = [
  "bindgen",
  "cc",
@@ -728,23 +742,23 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -752,6 +766,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pathfinder_geometry"
@@ -765,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0444332826c70dc47be74a7c6a5fc44e23a7905ad6858d4162b658320455ef93"
+checksum = "5cf07ef4804cfa9aea3b04a7bbdd5a40031dbb6b4f2cbaf2b011666c80c5b4f2"
 dependencies = [
  "rustc_version",
 ]
@@ -781,12 +801,6 @@ dependencies = [
  "digest",
  "hmac",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkg-config"
@@ -938,6 +952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,22 +974,34 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1025,18 +1057,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,19 +1183,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1173,9 +1235,21 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1185,9 +1259,21 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1197,9 +1283,21 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1233,11 +1331,10 @@ checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "3.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bbd69036d397ebbff671b1b8e4d918610c181c5a16073b96f984a38d08c386"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
 dependencies = [
- "const-cstr",
  "dlib",
  "once_cell",
  "pkg-config",
@@ -1265,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
 dependencies = [
  "aes",
  "arbitrary",
@@ -1308,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,15 @@ categories = ["encoding", "filesystem", "parser-implementations", "text-processi
 
 [dependencies]
 itertools = "0.13.0" # MIT or Apache-2.0
-thiserror = "1.0.58" # MIT or Apache-2.0
+thiserror = "1.0" # MIT or Apache-2.0
 linkify = { version = "0.10.0"} # MIT or Apache-2.0
-mupdf = { version = "0.4.2", optional = true } # AGPL-3.0
-zip = { version = "2.1.3", optional = true } # MIT
-xml-rs = { version = "0.8.20", optional = true } # MIT
+mupdf = { version = "0.4", optional = true } # AGPL-3.0
+zip = { version = "2.2", optional = true } # MIT
+xml-rs = { version = "0.8", optional = true } # MIT
 rtf-parser = { version = "0.3.0", optional = true } # MIT
 infer = { version = "0.16.0", optional = true } # MIT
 kamadak-exif = { version = "0.5.5", optional = true} # BSD-2-Clause
+cfg-if = "1.0.0"
 
 [features]
 default = ["any_format", "plaintext"]

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -235,10 +235,10 @@ gen_try_format!(try_image(impl BufRead + Seek), "image", image, ImageLink => scr
 
 #[cfg(feature = "svg")]
 fn try_svg(reader: impl Read) -> Result<Vec<Link>, LinkScrapingError> {
-    return Ok(crate::formats::xml::svg::scrape(reader)?
+    Ok(crate::formats::xml::svg::scrape(reader)?
         .into_iter()
         .map(|link| Link::SvgLink(link))
-        .collect());
+        .collect())
 }
 #[cfg(not(feature = "svg"))]
 fn try_svg(_: impl Read) -> Result<Vec<Link>, LinkScrapingError> {

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -153,7 +153,10 @@ impl Display for Link {
     }
 }
 
-fn scrape_from_buffer<R>(mut reader: R, file_type: Type) -> Result<Vec<Link>, LinkScrapingError> {
+fn scrape_from_buffer<R>(mut reader: R, file_type: Type) -> Result<Vec<Link>, LinkScrapingError>
+where
+    R: BufRead + Seek,
+{
     match file_type.mime_type() {
         "text/plain" | "text/csv" | "text/css" | "application/json" => Ok(try_text_file(reader)?),
 

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -207,10 +207,10 @@ where
 }
 
 macro_rules! gen_try_format {
-    ($name:ident($ty:ty), $feature:literal, $module:ident, $link:ident) => {
+    ($name:ident($ty:ty), $feature:literal, $module:ident, $link:ident => $scrape: ident) => {
         #[cfg(feature = $feature)]
         fn $name(value: $ty) -> Result<Vec<Link>, LinkScrapingError> {
-            return Ok(crate::formats::$module::scrape(value)?.into_iter().map(|link| Link::$link(link)).collect());
+            return Ok(crate::formats::$module::$scrape(value)?.into_iter().map(|link| Link::$link(link)).collect());
         }
 
         #[cfg(not(feature = $feature))]
@@ -224,14 +224,14 @@ gen_try_format!(
     try_text_file(impl BufRead),
     "plaintext",
     plaintext,
-    TextFileLink
+    TextFileLink => scrape
 );
-gen_try_format!(try_ooxml(impl Read + Seek), "ooxml", ooxml, OoxmlLink);
-gen_try_format!(try_odf(impl Read + Seek), "odf", odf, OdfLink);
-gen_try_format!(try_pdf(impl AsRef<[u8]>), "pdf", pdf, PdfLink);
-gen_try_format!(try_rtf(impl AsRef<str>), "rtf", rtf, RtfLink);
-gen_try_format!(try_xml(impl Read), "xml", xml, XmlLink);
-gen_try_format!(try_image(impl BufRead + Seek), "image", image, ImageLink);
+gen_try_format!(try_ooxml(impl Read + Seek), "ooxml", ooxml, OoxmlLink => scrape);
+gen_try_format!(try_odf(impl Read + Seek), "odf", odf, OdfLink => scrape);
+gen_try_format!(try_pdf(impl AsRef<[u8]>), "pdf", pdf, PdfLink => scrape_from_slice);
+gen_try_format!(try_rtf(impl AsRef<str>), "rtf", rtf, RtfLink => scrape_from_string);
+gen_try_format!(try_xml(impl Read), "xml", xml, XmlLink => scrape);
+gen_try_format!(try_image(impl BufRead + Seek), "image", image, ImageLink => scrape);
 
 #[cfg(feature = "svg")]
 fn try_svg(reader: impl Read) -> Result<Vec<Link>, LinkScrapingError> {

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -1,42 +1,72 @@
-use std::fmt::{Display, Formatter};
-use std::io::read_to_string;
-use thiserror::Error;
-use crate::gen_scrape_from_file;
+use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use std::fmt::{Display, Formatter};
+use std::io::{read_to_string, BufRead, BufReader, Read, Seek};
+use thiserror::Error;
 
 /// Guesses the file-type and scrapes links from the file.
-pub fn scrape(bytes: &[u8]) -> Result<Vec<Link>, LinkScrapingError> {
-    let file_type = infer::get(&bytes);
+pub fn scrape<R>(mut reader: R) -> Result<Vec<Link>, LinkScrapingError>
+where
+    R: BufRead + Seek,
+{
+    fn infer_and_scrape<R>(mut reader: R) -> Result<Vec<Link>, LinkScrapingError>
+    where
+        R: BufRead + Seek,
+    {
+        if let Some(file_type) = infer::get(reader.fill_buf()?) {
+            match file_type.mime_type() {
+                "text/plain" | "text/csv" | "text/css" | "application/json" => {
+                    Ok(try_text_file(reader)?)
+                }
 
-    if file_type == None {
-        return Ok(find_urls(&read_to_string(bytes)?).iter().map(|link| Link::StringLink(link.as_str().to_string())).collect());
+                "application/vnd.oasis.opendocument.text"
+                | "application/vnd.oasis.opendocument.spreadsheet"
+                | "application/vnd.oasis.opendocument.template"
+                | "application/vnd.oasis.opendocument.presentation" => Ok(try_odf(reader)?),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => {
+                    Ok(try_ooxml(reader)?)
+                }
+
+                "application/zip" => {
+                    let mut bytes = Vec::new();
+                    reader.read_to_end(&mut bytes)?;
+                    try_zip(bytes)
+                }
+                "application/pdf" => {
+                    let mut bytes = Vec::new();
+                    reader.read_to_end(&mut bytes)?;
+                    Ok(try_pdf(bytes)?)
+                }
+                "application/rtf" => Ok(try_rtf(reader)?),
+                "image/svg+xml" => Ok(try_svg(reader)?),
+                "text/xml" | "text/html" => Ok(try_xml(reader)?),
+
+                "image/jpeg" | "image/png" | "image/tiff" | "image/webp" | "image/heic"
+                | "image/heif" => Ok(try_image(reader)?),
+
+                _ => Err(LinkScrapingError::FileTypeNotImplemented(
+                    file_type.mime_type().to_string(),
+                )),
+            }
+        } else {
+            return Ok(find_urls(&read_to_string(reader)?)
+                .iter()
+                .map(|link| Link::StringLink(link.as_str().to_string()))
+                .collect());
+        }
     }
-    let file_type = file_type.unwrap();
 
-    match file_type.mime_type() {
-        "text/plain" | "text/csv" | "text/css" | "application/json"
-        => Ok(try_text_file(bytes)?),
-
-        "application/vnd.oasis.opendocument.text" | "application/vnd.oasis.opendocument.spreadsheet" |
-        "application/vnd.oasis.opendocument.template" | "application/vnd.oasis.opendocument.presentation"
-        => Ok(try_odf(bytes)?),
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        => Ok(try_ooxml(bytes)?),
-
-        "application/zip" => try_zip(bytes),
-        "application/pdf" => Ok(try_pdf(bytes)?),
-        "application/rtf" => Ok(try_rtf(bytes)?),
-
-        "image/svg+xml" => Ok(try_svg(bytes)?),
-        "text/xml" | "text/html" => Ok(try_xml(bytes)?),
-
-        "image/jpeg" | "image/png" | "image/tiff" | "image/webp" | "image/heic" | "image/heif"
-        => Ok(try_image(bytes)?),
-
-        _ => Err(LinkScrapingError::FileTypeNotImplemented(file_type.mime_type().to_string()))
+    match reader.fill_buf()?.len() {
+        0 => Ok(Vec::with_capacity(0)),
+        // infer get_from_path uses a buffer of the size 8192 (see infer::Infer::get_from_path)
+        // Therefore we haveto make sure,that we grab at least this amount of data when
+        // processing it.
+        1..8192 => infer_and_scrape(BufReader::with_capacity(8192, reader)),
+        // If we have 8192 or more, we can just use the existing buffer.
+        _ => infer_and_scrape(reader),
     }
 }
-gen_scrape_from_file!(Result<Vec<Link>, LinkScrapingError>);
+gen_scrape_froms!(scrape(Read) -> Result<Vec<Link>, LinkScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum LinkScrapingError {
@@ -82,7 +112,7 @@ pub enum LinkScrapingError {
     FileTypeNotImplemented(String),
 
     #[error("Scraping failed")]
-    ScrapingFailedError(String)
+    ScrapingFailedError(String),
 }
 
 #[derive(Debug, Clone)]
@@ -109,71 +139,115 @@ pub enum Link {
 impl Display for Link {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Link::StringLink(link) => {write!(f, "StringLink({})", link)}
+            Link::StringLink(link) => {
+                write!(f, "StringLink({})", link)
+            }
             #[cfg(feature = "plaintext")]
-            Link::TextFileLink(link) => {write!(f, "TextFileLink({})", link)}
+            Link::TextFileLink(link) => {
+                write!(f, "TextFileLink({})", link)
+            }
             #[cfg(feature = "ooxml")]
-            Link::OoxmlLink(link) => {write!(f, "OoxmlLink({})", link)}
+            Link::OoxmlLink(link) => {
+                write!(f, "OoxmlLink({})", link)
+            }
             #[cfg(feature = "odf")]
-            Link::OdfLink(link) => {write!(f, "OdfLink({})", link)}
+            Link::OdfLink(link) => {
+                write!(f, "OdfLink({})", link)
+            }
             #[cfg(feature = "pdf")]
-            Link::PdfLink(link) => {write!(f, "PdfLink({})", link)}
+            Link::PdfLink(link) => {
+                write!(f, "PdfLink({})", link)
+            }
             #[cfg(feature = "rtf")]
-            Link::RtfLink(link) => {write!(f, "RtfLink({})", link)}
+            Link::RtfLink(link) => {
+                write!(f, "RtfLink({})", link)
+            }
             #[cfg(feature = "xml")]
-            Link::XmlLink(link) => {write!(f, "XmlLink({})", link)}
+            Link::XmlLink(link) => {
+                write!(f, "XmlLink({})", link)
+            }
             #[cfg(feature = "svg")]
-            Link::SvgLink(link) => {write!(f, "SvgLink({})", link)}
+            Link::SvgLink(link) => {
+                write!(f, "SvgLink({})", link)
+            }
             #[cfg(feature = "image")]
-            Link::ImageLink(link) => {write!(f, "ImageLink({})", link)}
+            Link::ImageLink(link) => {
+                write!(f, "ImageLink({})", link)
+            }
         }
     }
 }
 
 macro_rules! gen_try_format {
-    ($name:ident, $feature:literal, $module:ident, $link:ident) => {
-        fn $name(bytes: &[u8]) -> Result<Vec<Link>, LinkScrapingError> {
-            #[cfg(feature = $feature)]
-            return Ok(crate::formats::$module::scrape(bytes)?.into_iter().map(|link| Link::$link(link)).collect());
-            #[cfg(not(feature = $feature))]
+    ($name:ident($ty:ty), $feature:literal, $module:ident, $link:ident) => {
+        #[cfg(feature = $feature)]
+        fn $name(reader: $ty) -> Result<Vec<Link>, LinkScrapingError> {
+            return Ok(crate::formats::$module::scrape(reader)?.into_iter().map(|link| Link::$link(link)).collect());
+        }
+
+        #[cfg(not(feature = $feature))]
+        fn $name(_: $ty) -> Result<Vec<Link>, LinkScrapingError> {
             return Err(LinkScrapingError::FeatureNotEnabledError(format!("Detected {}-file but the corresponding feature is not enabled. Please enable it in your dependencies.", stringify!($feature))));
         }
     }
 }
 
-gen_try_format!(try_text_file, "plaintext", plaintext, TextFileLink);
-gen_try_format!(try_ooxml, "ooxml", ooxml, OoxmlLink);
-gen_try_format!(try_odf, "odf", odf, OdfLink);
-gen_try_format!(try_pdf, "pdf", pdf, PdfLink);
-gen_try_format!(try_rtf, "rtf", rtf, RtfLink);
-gen_try_format!(try_xml, "xml", xml, XmlLink);
-gen_try_format!(try_image, "image", image, ImageLink);
+gen_try_format!(
+    try_text_file(impl BufRead),
+    "plaintext",
+    plaintext,
+    TextFileLink
+);
+gen_try_format!(try_ooxml(impl Read + Seek), "ooxml", ooxml, OoxmlLink);
+gen_try_format!(try_odf(impl Read + Seek), "odf", odf, OdfLink);
+gen_try_format!(try_pdf(impl AsRef<[u8]>), "pdf", pdf, PdfLink);
+gen_try_format!(try_rtf(impl Read), "rtf", rtf, RtfLink);
+gen_try_format!(try_xml(impl Read), "xml", xml, XmlLink);
+gen_try_format!(try_image(impl BufRead + Seek), "image", image, ImageLink);
 
-fn try_svg(bytes: &[u8]) -> Result<Vec<Link>, LinkScrapingError> {
-    #[cfg(feature = "svg")]
-    return Ok(crate::formats::xml::svg::scrape(bytes)?.into_iter().map(|link| Link::SvgLink(link)).collect());
-    #[cfg(not(feature = "svg"))]
-    return Err(LinkScrapingError::FeatureNotEnabledError(format!("Detected svg-file but the corresponding feature is not enabled. Please enable it in your dependencies.")))
+#[cfg(feature = "svg")]
+fn try_svg(reader: impl Read) -> Result<Vec<Link>, LinkScrapingError> {
+    return Ok(crate::formats::xml::svg::scrape(reader)?
+        .into_iter()
+        .map(|link| Link::SvgLink(link))
+        .collect());
+}
+#[cfg(not(feature = "svg"))]
+fn try_svg(_: impl Read) -> Result<Vec<Link>, LinkScrapingError> {
+    return Err(LinkScrapingError::FeatureNotEnabledError(format!("Detected svg-file but the corresponding feature is not enabled. Please enable it in your dependencies.")));
 }
 
-fn try_zip(bytes: &[u8]) -> Result<Vec<Link>, LinkScrapingError> {
-    #[allow(unused_assignments)]
-        let ret: Result<Vec<Link>, LinkScrapingError> = Err(LinkScrapingError::FeatureNotEnabledError("Detected zip-file but the corresponding feature is not enabled. Please enable it in your dependencies.".to_string()));
-    #[cfg(feature = "ooxml")] {
-        let ooxml_result = try_ooxml(bytes).map_err(|e| LinkScrapingError::from(e));
-        if let Ok(res) = ooxml_result { return Ok(res) }
-    }
-    #[cfg(feature = "odf")] {
-        let odf_result = try_odf(bytes).map_err(|e| LinkScrapingError::from(e));
-        if let Ok(res) = odf_result { return Ok(res) }
-    }
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "ooxml", feature = "odf"))] {
+        fn try_zip(bytes: impl AsRef<[u8]>) -> Result<Vec<Link>, LinkScrapingError> {
+            #[cfg(feature = "ooxml")] {
+                let ooxml_result = try_ooxml(std::io::Cursor::new(bytes.as_ref())).map_err(|e| LinkScrapingError::from(e));
+                if let Ok(res) = ooxml_result { return Ok(res); }
+            }
 
-    ret
+            #[cfg(feature = "odf")] {
+                let odf_result = try_odf(std::io::Cursor::new(bytes.as_ref())).map_err(|e| LinkScrapingError::from(e));
+                if let Ok(res) = odf_result { return Ok(res); }
+            }
+
+            #[cfg(all(feature = "ooxml", feature = "odf"))] {
+                return Err(LinkScrapingError::FileTypeNotImplemented("Detected zip-file but the corresponding type is not supported!".to_string()));
+            }
+            #[cfg(not(all(feature = "ooxml", feature = "odf")))] {
+                return Err(LinkScrapingError::FeatureNotEnabledError("Detected zip-file but the corresponding feature is not enabled. Please enable it in your dependencies.".to_string()));
+            }
+        }
+    } else {
+        fn try_zip(_: impl AsRef<[u8]>) -> Result<Vec<Link>, LinkScrapingError> {
+            Err(LinkScrapingError::FeatureNotEnabledError("Detected zip-file but the corresponding feature is not enabled. Please enable it in your dependencies.".to_string()))
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
     use std::include_bytes;
 
     const TEST_DOCX: &[u8] = include_bytes!("../test_files/ooxml/docx_test.docx");
@@ -189,33 +263,44 @@ mod tests {
     const TEST_SVG: &[u8] = include_bytes!("../test_files/xml/svg_test.svg");
     const TEST_JPG: &[u8] = include_bytes!("../test_files/images/exif_test.jpg");
 
-    #[test]
-    fn scrape_generic_file_test() {
-        println!("{}", LinkVec(scrape(b"http://test.com/").unwrap()));
-        println!("{}", LinkVec(scrape(TEST_DOCX).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_PPTX).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_XLSX).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_ODT).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_ODS).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_OTT).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_ODP).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_PDF).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_RTF).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_XML).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_SVG).unwrap()));
-        println!("{}", LinkVec(scrape(TEST_JPG).unwrap()));
+    macro_rules! is_active {
+        ($name: literal) => {{
+            if cfg!(feature = $name) {
+                true
+            } else {
+                false
+            }
+        }};
     }
 
-
-    #[derive(Debug)]
-    struct LinkVec(Vec<Link>);
-    impl Display for LinkVec {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "[")?;
-            for link in &self.0 {
-                write!(f, "{}, ", link)?;
+    #[test]
+    fn scrape_generic_file_test() {
+        fn scrape(slice: &[u8], is_active: bool) {
+            if is_active {
+                println!(
+                    "[\"{}\"]",
+                    scrape_from_slice(slice)
+                        .expect("Failed to scrape a specific format!")
+                        .into_iter()
+                        .join("\", \"")
+                );
+            } else {
+                scrape_from_slice(slice).expect_err("Expected to fail!");
             }
-            write!(f, "]")
         }
+
+        scrape(b"https://test.com/", true);
+        scrape(TEST_DOCX, is_active!("ooxml"));
+        scrape(TEST_PPTX, is_active!("ooxml"));
+        scrape(TEST_XLSX, is_active!("ooxml"));
+        scrape(TEST_ODT, is_active!("odf"));
+        scrape(TEST_ODS, is_active!("odf"));
+        scrape(TEST_OTT, is_active!("odf"));
+        scrape(TEST_ODP, is_active!("odf"));
+        scrape(TEST_PDF, is_active!("pdf"));
+        scrape(TEST_RTF, is_active!("rtf"));
+        scrape(TEST_XML, is_active!("xml"));
+        scrape(TEST_SVG, is_active!("svg"));
+        scrape(TEST_JPG, is_active!("image"));
     }
 }

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -24,6 +24,7 @@ where
         }
     }
 
+    // We do not consume because we want to use the complete buffer later.
     let buf = reader.fill_buf()?;
     match buf.len() {
         0 => Ok(Vec::with_capacity(0)),

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -28,8 +28,8 @@ where
     let buf = reader.fill_buf()?;
     match buf.len() {
         0 => Ok(Vec::with_capacity(0)),
-        // infer get_from_path uses a buffer of the size 8192 (see infer::Infer::get_from_path)
-        // Therefore we haveto make sure,that we grab at least this amount of data when
+        // Infer uses a buffer of the size 8192 for inferring files. (see infer::Infer::get_from_path)
+        // Therefore we have to make sure,that we grab at least this amount of data when
         // processing it.
         1..8192 => {
             if let Some(found) = infer::get(buf) {
@@ -38,7 +38,7 @@ where
                 infer_and_scrape(BufReader::with_capacity(8192, reader))
             }
         }
-        // If we have 8192 or more, we can just use the existing buffer.
+        // If we have 8192 bytes or more, we can just use the existing buffer.
         _ => infer_and_scrape(reader),
     }
 }

--- a/src/any_format_scraper.rs
+++ b/src/any_format_scraper.rs
@@ -1,4 +1,4 @@
-use crate::gen_scrape_froms;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use crate::helpers::find_urls;
 use infer::Type;
 use std::fmt::{Display, Formatter};
@@ -42,7 +42,8 @@ where
         _ => infer_and_scrape(reader),
     }
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<Link>, LinkScrapingError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<Link>, LinkScrapingError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<Link>, LinkScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum LinkScrapingError {

--- a/src/formats/compressed_formats_common.rs
+++ b/src/formats/compressed_formats_common.rs
@@ -1,22 +1,60 @@
-use std::io::{Cursor, Read};
-use itertools::Itertools;
-use zip::result::ZipError;
 use crate::helpers::find_urls;
+use itertools::Itertools;
+use std::error::Error;
+use std::io::{Read, Seek};
+use zip::read::ZipFile;
+use zip::result::ZipError;
 
 /// Scrapes all links from a given compressed file.
 ///
 /// To avoid getting urls related to the ooxml-functionalities use [`scrape`] instead.
-pub(crate) fn scrape_unfiltered(bytes: &[u8]) -> Result<Vec<String>, ZipError> {
-    let cur = Cursor::new(bytes);
-    let mut archive = zip::ZipArchive::new(cur)?;
+pub(crate) fn scrape_unfiltered<R>(reader: R) -> Result<Vec<String>, ZipError>
+where
+    R: Read + Seek,
+{
+    let mut archive = zip::ZipArchive::new(reader)?;
 
     let mut links: Vec<String> = vec![];
-    for file_name in archive.file_names().map(|name| name.to_owned()).collect_vec() {
+    for file_name in archive
+        .file_names()
+        .map(|name| name.to_owned())
+        .collect_vec()
+    {
         let mut file_content = String::new();
-        if archive.by_name(&file_name)?.read_to_string(&mut file_content).is_err() {continue}
+        if archive
+            .by_name(&file_name)?
+            .read_to_string(&mut file_content)
+            .is_err()
+        {
+            continue;
+        }
 
-        find_urls(&file_content).iter().for_each(|link| links.push(link.as_str().to_string()))
+        find_urls(&file_content)
+            .iter()
+            .for_each(|link| links.push(link.as_str().to_string()))
     }
 
+    Ok(links)
+}
+
+pub(crate) fn unified_unzip_scrape<R, T, E, F>(reader: R, extractor: F) -> Result<Vec<T>, E>
+where
+    R: Read + Seek,
+    E: Error + From<std::io::Error> + From<ZipError>,
+    F: Fn(ZipFile<'_>, &str, &mut Vec<T>) -> Result<(), E>,
+{
+    let mut archive = zip::ZipArchive::new(reader)?;
+    let mut links: Vec<T> = vec![];
+    for file_name in archive
+        .file_names()
+        .map(|name| name.to_owned())
+        .collect_vec()
+    {
+        let content = archive.by_name(&file_name)?;
+        if content.size() == 0 {
+            continue;
+        }
+        extractor(content, &file_name, &mut links)?;
+    }
     Ok(links)
 }

--- a/src/formats/compressed_formats_common.rs
+++ b/src/formats/compressed_formats_common.rs
@@ -37,6 +37,7 @@ where
     Ok(links)
 }
 
+/// Takes a reader for some zipped bytes and tries to extract some data from it.
 pub(crate) fn unified_unzip_scrape<R, T, E, F>(reader: R, extractor: F) -> Result<Vec<T>, E>
 where
     R: Read + Seek,

--- a/src/formats/image.rs
+++ b/src/formats/image.rs
@@ -3,8 +3,8 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use thiserror::Error;
 
-use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 
 pub fn scrape<R>(mut reader: R) -> Result<Vec<ImageLink>, ImageScrapingError>
 where
@@ -35,7 +35,8 @@ where
         .flatten()
         .collect())
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<ImageLink>, ImageScrapingError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<ImageLink>, ImageScrapingError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<ImageLink>, ImageScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum ImageScrapingError {

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,20 +1,20 @@
+#[cfg(any(feature = "odf", feature = "ooxml"))]
+mod compressed_formats_common;
+#[cfg(feature = "image")]
+pub mod image;
+#[cfg(feature = "odf")]
+/// .odt, .ods, .odp
+pub mod odf;
+#[cfg(feature = "ooxml")]
+/// .docx, .pptx, .xlsx
+pub mod ooxml;
 #[cfg(feature = "pdf")]
 pub mod pdf;
 #[cfg(feature = "plaintext")]
 /// Any plaintext-format
 pub mod plaintext;
-#[cfg(feature = "ooxml")]
-/// .docx, .pptx, .xlsx
-pub mod ooxml;
 #[cfg(feature = "rtf")]
 pub mod rtf;
-#[cfg(feature = "odf")]
-/// .odt, .ods, .odp
-pub mod odf;
 #[cfg(any(feature = "xml", feature = "xlink"))]
 /// Also contains xml-based formats
 pub mod xml;
-#[cfg(any(feature = "odf", feature = "ooxml"))]
-mod compressed_formats_common;
-#[cfg(feature = "image")]
-pub mod image;

--- a/src/formats/odf.rs
+++ b/src/formats/odf.rs
@@ -1,38 +1,31 @@
+use crate::formats::compressed_formats_common::unified_unzip_scrape;
+use crate::formats::odf::OdfLinkKind::{Hyperlink, PlainText};
+use crate::gen_scrape_froms;
+use crate::helpers::find_urls;
 use std::fmt::{Display, Formatter};
-use std::io::{Cursor};
-use itertools::Itertools;
+use std::io::{Read, Seek};
 use thiserror::Error;
 use xml::common::{Position, TextPosition};
-use xml::EventReader;
 use xml::reader::XmlEvent;
-use crate::formats::odf::OdfLinkKind::{Hyperlink, PlainText};
-use crate::gen_scrape_from_file;
-use crate::helpers::find_urls;
+use xml::EventReader;
 
 /// Scrapes all links from a given ooxml-file
 ///
 /// Tries to filter out urls related to ooxml-functionalities, but might be a bit too aggressive at times
 /// if there are links missing from the output, use [`scrape_unfiltered`]
-pub fn scrape(bytes: &[u8]) -> Result<Vec<OdfLink>, OdfScrapingError> {
-    let cur = Cursor::new(bytes);
-    let mut archive = zip::ZipArchive::new(cur)?;
-
-    let mut links: Vec<OdfLink> = vec![];
-    for file_name in archive.file_names().map(|name| name.to_owned()).collect_vec() {
-        let mut file_content = vec![];
-        archive.by_name(&file_name)?.read_to_end(&mut file_content)?;
-        if file_content.is_empty() {
-            continue;
-        }
-
+pub fn scrape<R>(reader: R) -> Result<Vec<OdfLink>, OdfScrapingError>
+where
+    R: Read + Seek,
+{
+    unified_unzip_scrape(reader, |reader, file_name, links| {
         if file_name.ends_with(".xml") {
-            scrape_from_xml_file(file_content.as_slice(), &file_name, &mut links)?
+            scrape_from_xml_file(reader, &file_name, links)
+        } else {
+            Ok(())
         }
-    }
-
-    Ok(links)
+    })
 }
-gen_scrape_from_file!(Result<Vec<OdfLink>, OdfScrapingError>);
+gen_scrape_froms!(scrape(Read) -> Result<Vec<OdfLink>, OdfScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum OdfScrapingError {
@@ -61,7 +54,7 @@ impl Display for OdfLink {
 #[derive(Debug, Clone, PartialEq)]
 pub struct OdfLinkLocation {
     pub file: String,
-    pub position: TextPosition
+    pub position: TextPosition,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -69,14 +62,17 @@ pub enum OdfLinkKind {
     /// The link is contained as Text or as a Comment inside the document
     PlainText,
     /// The link is contained as a Hyperlink inside the document
-    Hyperlink
+    Hyperlink,
 }
 
 /// Scrapes all links from a given odf file.
 ///
 /// To avoid getting urls related to odf-functionalities use [`crate::formats::ooxml::scrape`] instead.
-pub fn scrape_unfiltered(bytes: &[u8]) -> Result<Vec<String>, OdfScrapingError> {
-    crate::formats::compressed_formats_common::scrape_unfiltered(bytes)
+pub fn scrape_unfiltered<R>(reader: R) -> Result<Vec<String>, OdfScrapingError>
+where
+    R: Read + Seek,
+{
+    crate::formats::compressed_formats_common::scrape_unfiltered(reader)
         .map_err(|e| OdfScrapingError::from(e))
 }
 
@@ -84,37 +80,51 @@ pub fn scrape_unfiltered(bytes: &[u8]) -> Result<Vec<String>, OdfScrapingError> 
 ///
 /// All tags and tag-attributes are omitted to filter out functional urls.
 /// This might be too aggressive in some cases though
-fn scrape_from_xml_file(data: impl Read, filename: &str, collector: &mut Vec<OdfLink>) -> Result<(), OdfScrapingError> {
+fn scrape_from_xml_file(
+    data: impl Read,
+    filename: &str,
+    collector: &mut Vec<OdfLink>,
+) -> Result<(), OdfScrapingError> {
     let mut parser = EventReader::new(data);
 
     while let Ok(xml_event) = &parser.next() {
         match xml_event {
-            XmlEvent::StartElement { name, attributes, .. } => {
-                if name.local_name != "a" { continue }
+            XmlEvent::StartElement {
+                name, attributes, ..
+            } => {
+                if name.local_name != "a" {
+                    continue;
+                }
 
-                let maybe_href = &attributes.iter()
+                let maybe_href = &attributes
+                    .iter()
                     .find(|&attr| attr.name.local_name == "href");
                 if let Some(href) = maybe_href {
                     let link = OdfLink {
                         url: href.value.to_string(),
-                        location: OdfLinkLocation { file: filename.to_string(), position: parser.position() },
+                        location: OdfLinkLocation {
+                            file: filename.to_string(),
+                            position: parser.position(),
+                        },
                         kind: Hyperlink,
                     };
                     collector.push(link);
                 }
-            },
-            XmlEvent::Characters(chars) => {
-                collector.append(&mut find_urls(&chars)
+            }
+            XmlEvent::Characters(chars) => collector.append(
+                &mut find_urls(&chars)
                     .iter()
                     .map(|link| OdfLink {
                         url: link.as_str().to_string(),
-                        location: OdfLinkLocation {file: filename.to_string(), position: parser.position()},
+                        location: OdfLinkLocation {
+                            file: filename.to_string(),
+                            position: parser.position(),
+                        },
                         kind: PlainText,
                     })
-                    .collect()
-                )
-            }
-            XmlEvent::EndDocument => { break }
+                    .collect(),
+            ),
+            XmlEvent::EndDocument => break,
             _ => {}
         };
     }
@@ -125,6 +135,7 @@ fn scrape_from_xml_file(data: impl Read, filename: &str, collector: &mut Vec<Odf
 mod tests {
     use super::*;
     use std::include_bytes;
+    use std::io::Cursor;
 
     const TEST_ODT: &[u8] = include_bytes!("../../test_files/odf/odt_test.odt");
     const TEST_ODS: &[u8] = include_bytes!("../../test_files/odf/ods_test.ods");
@@ -133,39 +144,55 @@ mod tests {
 
     #[test]
     pub fn scrape_odt_test() {
-        let links = scrape(TEST_ODT).unwrap();
+        let links = scrape_from_slice(TEST_ODT).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
     }
 
     #[test]
     pub fn scrape_ods_test() {
-        let links = scrape(TEST_ODS).unwrap();
+        let links = scrape_from_slice(TEST_ODS).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
     }
 
     #[test]
     pub fn scrape_odp_test() {
-        let links = scrape(TEST_ODP).unwrap();
+        let links = scrape_from_slice(TEST_ODP).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
     }
 
     #[test]
     pub fn scrape_ott_test() {
-        let links = scrape(TEST_OTT).unwrap();
+        let links = scrape_from_slice(TEST_OTT).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
     }
 
     #[test]
     pub fn scrape_unfiltered_test() {
-        let links = scrape_unfiltered(TEST_ODT).unwrap();
+        let links = scrape_unfiltered(Cursor::new(TEST_ODT)).unwrap();
         assert_eq!(links.len(), 47);
     }
 }

--- a/src/formats/odf.rs
+++ b/src/formats/odf.rs
@@ -1,7 +1,7 @@
 use crate::formats::compressed_formats_common::unified_unzip_scrape;
 use crate::formats::odf::OdfLinkKind::{Hyperlink, PlainText};
-use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use std::fmt::{Display, Formatter};
 use std::io::{Read, Seek};
 use thiserror::Error;
@@ -25,7 +25,8 @@ where
         }
     })
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<OdfLink>, OdfScrapingError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<OdfLink>, OdfScrapingError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<OdfLink>, OdfScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum OdfScrapingError {

--- a/src/formats/ooxml.rs
+++ b/src/formats/ooxml.rs
@@ -1,7 +1,7 @@
 use crate::formats::compressed_formats_common::unified_unzip_scrape;
 use crate::formats::ooxml::OoxmlLinkKind::{Comment, Hyperlink, PlainText};
-use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use std::fmt::{Display, Formatter};
 use std::io::{Cursor, Read, Seek};
 use thiserror::Error;
@@ -27,7 +27,8 @@ where
         }
     })
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<OoxmlLink>, OoxmlScrapingError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<OoxmlLink>, OoxmlScrapingError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<OoxmlLink>, OoxmlScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum OoxmlScrapingError {

--- a/src/formats/ooxml.rs
+++ b/src/formats/ooxml.rs
@@ -1,40 +1,33 @@
+use crate::formats::compressed_formats_common::unified_unzip_scrape;
+use crate::formats::ooxml::OoxmlLinkKind::{Comment, Hyperlink, PlainText};
+use crate::gen_scrape_froms;
+use crate::helpers::find_urls;
 use std::fmt::{Display, Formatter};
-use std::io::{Cursor};
-use itertools::Itertools;
+use std::io::{Cursor, Read, Seek};
 use thiserror::Error;
 use xml::common::{Position, TextPosition};
-use xml::EventReader;
 use xml::reader::XmlEvent;
-use crate::formats::ooxml::OoxmlLinkKind::{Comment, Hyperlink, PlainText};
-use crate::gen_scrape_from_file;
-use crate::helpers::find_urls;
+use xml::EventReader;
 
 /// Scrapes all links from a given ooxml-file
 ///
 /// Tries to filter out urls related to ooxml-functionalities, but might be a bit too aggressive at times
 /// if there are links missing from the output, use [`scrape_unfiltered`]
-pub fn scrape(bytes: &[u8]) -> Result<Vec<OoxmlLink>, OoxmlScrapingError> {
-    let cur = Cursor::new(bytes);
-    let mut archive = zip::ZipArchive::new(cur)?;
-
-    let mut links: Vec<OoxmlLink> = vec![];
-    for file_name in archive.file_names().map(|name| name.to_owned()).collect_vec() {
-        let mut file_content = vec![];
-        archive.by_name(&file_name)?.read_to_end(&mut file_content)?;
-        if file_content.is_empty() {
-            continue;
-        }
-
+pub fn scrape<R>(reader: R) -> Result<Vec<OoxmlLink>, OoxmlScrapingError>
+where
+    R: Read + Seek,
+{
+    unified_unzip_scrape(reader, |reader, file_name, links| {
         if file_name.ends_with(".rels") {
-            scrape_from_rels_file(file_content.as_slice(), &file_name, &mut links)?
+            scrape_from_rels_file(reader, &file_name, links)
         } else if file_name.ends_with(".xml") {
-            scrape_from_xml_file(file_content.as_slice(), &file_name, &mut links)?
+            scrape_from_xml_file(reader, &file_name, links)
+        } else {
+            Ok(())
         }
-    }
-
-    Ok(links)
+    })
 }
-gen_scrape_from_file!(Result<Vec<OoxmlLink>, OoxmlScrapingError>);
+gen_scrape_froms!(scrape(Read) -> Result<Vec<OoxmlLink>, OoxmlScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum OoxmlScrapingError {
@@ -63,7 +56,7 @@ impl Display for OoxmlLink {
 #[derive(Debug, Clone)]
 pub struct OoxmlLinkLocation {
     pub file: String,
-    pub position: TextPosition
+    pub position: TextPosition,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -73,33 +66,63 @@ pub enum OoxmlLinkKind {
     /// The link is contained as a Hyperlink inside the document
     Hyperlink,
     /// The link is contained as a Comment added to the document
-    Comment
+    Comment,
 }
 
 /// Scrapes all links from a given ooxml file.
 ///
 /// To avoid getting urls related to ooxml-functionalities use [`scrape`] instead.
-pub fn scrape_unfiltered(bytes: &[u8]) -> Result<Vec<String>, OoxmlScrapingError> {
-    crate::formats::compressed_formats_common::scrape_unfiltered(bytes)
+pub fn scrape_unfiltered<R>(reader: R) -> Result<Vec<String>, OoxmlScrapingError>
+where
+    R: Read + Seek,
+{
+    crate::formats::compressed_formats_common::scrape_unfiltered(reader)
         .map_err(|e| OoxmlScrapingError::from(e))
 }
 
+/// Scrapes all links from a given ooxml file.
+///
+/// To avoid getting urls related to ooxml-functionalities use [`scrape`] instead.
+pub fn scrape_unfiltered_from_slice(
+    bytes: impl AsRef<[u8]>,
+) -> Result<Vec<String>, OoxmlScrapingError> {
+    scrape_unfiltered(Cursor::new(bytes))
+}
+
 /// Scrapes links from given .rels file
-fn scrape_from_rels_file(data: impl Read, file_name: &str, collector: &mut Vec<OoxmlLink>) -> Result<(), OoxmlScrapingError> {
+fn scrape_from_rels_file(
+    data: impl Read,
+    file_name: &str,
+    collector: &mut Vec<OoxmlLink>,
+) -> Result<(), OoxmlScrapingError> {
     let mut parser = EventReader::new(data);
     while let Ok(xml_event) = &parser.next() {
-        if let XmlEvent::StartElement { name: _, attributes, .. } = xml_event {
-            let attributes_with_potential_links = attributes.iter().filter(|att| &att.name.local_name != "Type");
+        if let XmlEvent::StartElement {
+            name: _,
+            attributes,
+            ..
+        } = xml_event
+        {
+            let attributes_with_potential_links = attributes
+                .iter()
+                .filter(|att| &att.name.local_name != "Type");
             for attribute in attributes_with_potential_links {
-                find_urls(&attribute.value).iter().for_each(|link| collector.push(OoxmlLink {
-                    url: link.as_str().to_string(),
-                    location: OoxmlLinkLocation { file: file_name.to_string(), position: parser.position()},
-                    kind: Hyperlink
-                }))
+                find_urls(&attribute.value).iter().for_each(|link| {
+                    collector.push(OoxmlLink {
+                        url: link.as_str().to_string(),
+                        location: OoxmlLinkLocation {
+                            file: file_name.to_string(),
+                            position: parser.position(),
+                        },
+                        kind: Hyperlink,
+                    })
+                })
             }
         }
 
-        if let XmlEvent::EndDocument{} = xml_event { break }
+        if let XmlEvent::EndDocument {} = xml_event {
+            break;
+        }
     }
     Ok(())
 }
@@ -108,30 +131,45 @@ fn scrape_from_rels_file(data: impl Read, file_name: &str, collector: &mut Vec<O
 ///
 /// All tags and tag-attributes are omitted to filter out functional urls.
 /// This might be too aggressive in some cases though
-fn scrape_from_xml_file(data: impl Read, file_name: &str, collector: &mut Vec<OoxmlLink>) -> Result<(), OoxmlScrapingError>{
+fn scrape_from_xml_file(
+    data: impl Read,
+    file_name: &str,
+    collector: &mut Vec<OoxmlLink>,
+) -> Result<(), OoxmlScrapingError> {
     let mut parser = EventReader::new(data);
     while let Ok(xml_event) = &parser.next() {
         let raw_text = match xml_event {
             XmlEvent::Characters(str) => Some(str),
             XmlEvent::Whitespace(str) => Some(str),
-            _ => None
+            _ => None,
         };
         if let Some(text) = raw_text {
-            find_urls(&text).iter().for_each(|link| collector.push(OoxmlLink {
-                url: link.as_str().to_string(),
-                location: OoxmlLinkLocation { file: file_name.to_string(), position: parser.position()},
-                kind: if file_name.contains("/comment") { Comment }
-                    else {
-                        if file_name.contains("/_rels/") { Hyperlink } else { PlainText }
-                    }
-            }));
+            find_urls(&text).iter().for_each(|link| {
+                collector.push(OoxmlLink {
+                    url: link.as_str().to_string(),
+                    location: OoxmlLinkLocation {
+                        file: file_name.to_string(),
+                        position: parser.position(),
+                    },
+                    kind: if file_name.contains("/comment") {
+                        Comment
+                    } else {
+                        if file_name.contains("/_rels/") {
+                            Hyperlink
+                        } else {
+                            PlainText
+                        }
+                    },
+                })
+            });
         }
 
-        if let XmlEvent::EndDocument{} = xml_event { break }
+        if let XmlEvent::EndDocument {} = xml_event {
+            break;
+        }
     }
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -144,34 +182,52 @@ mod tests {
 
     #[test]
     pub fn scrape_docx_test() {
-        let links = scrape(TEST_DOCX).unwrap();
+        let links = scrape_from_slice(TEST_DOCX).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
-        assert!(links.iter().any(|it| it.url == "https://comment.test.com" && it.kind == Comment));
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://comment.test.com" && it.kind == Comment));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
     }
 
     #[test]
     pub fn scrape_pptx_test() {
-        let links = scrape(TEST_PPTX).unwrap();
+        let links = scrape_from_slice(TEST_PPTX).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
-        assert!(links.iter().any(|it| it.url == "https://comment.test.com/" && it.kind == Comment));
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://comment.test.com/" && it.kind == Comment));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
     }
 
     #[test]
     pub fn scrape_xlsx_test() {
-        let links = scrape(TEST_XLSX).unwrap();
+        let links = scrape_from_slice(TEST_XLSX).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
-        assert!(links.iter().any(|it| it.url == "https://comment.test.com" && it.kind == Comment));
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://hyperlink.test.com/" && it.kind == Hyperlink));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://comment.test.com" && it.kind == Comment));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com" && it.kind == PlainText));
     }
 
     #[test]
     pub fn scrape_unfiltered_test() {
-        let mut links = scrape_unfiltered(TEST_DOCX).unwrap();
+        let mut links = scrape_unfiltered_from_slice(TEST_DOCX).unwrap();
         links.sort();
         assert_eq!(links.len(), 50);
     }

--- a/src/formats/pdf.rs
+++ b/src/formats/pdf.rs
@@ -22,9 +22,7 @@ where
     reader.read_to_end(&mut buffer)?;
     scrape_from_slice(buffer)
 }
-gen_scrape_froms!(
-    scrape_from_slice(AsRef<[u8]>, no_slice) -> Result<Vec<PdfLink>, PdfScrapingError>
-);
+gen_scrape_froms!(scrape_from_slice(AsRef<[u8]>) -> Result<Vec<PdfLink>, PdfScrapingError>);
 
 /// Takes a PDF as a byte slice and scrapes all links from it.
 ///

--- a/src/formats/pdf.rs
+++ b/src/formats/pdf.rs
@@ -1,5 +1,5 @@
 use crate::formats::rtf::scrape_from_string;
-use crate::gen_scrape_froms;
+use crate::gen_scrape_from_file;
 use crate::helpers::find_urls;
 use itertools::Itertools;
 use mupdf::{Document, Page};
@@ -22,7 +22,7 @@ where
     reader.read_to_end(&mut buffer)?;
     scrape_from_slice(buffer)
 }
-gen_scrape_froms!(scrape_from_slice(AsRef<[u8]>) -> Result<Vec<PdfLink>, PdfScrapingError>);
+gen_scrape_from_file!(scrape_from_slice(AsRef<[u8]>) -> Result<Vec<PdfLink>, PdfScrapingError>);
 
 /// Takes a PDF as a byte slice and scrapes all links from it.
 ///

--- a/src/formats/pdf.rs
+++ b/src/formats/pdf.rs
@@ -1,10 +1,8 @@
-use crate::formats::rtf::scrape_from_string;
 use crate::gen_scrape_from_file;
 use crate::helpers::find_urls;
-use itertools::Itertools;
 use mupdf::{Document, Page};
 use std::fmt::{Display, Formatter};
-use std::io::{BufRead, Read};
+use std::io::{Read};
 use std::string::String;
 use thiserror::Error;
 

--- a/src/formats/plaintext.rs
+++ b/src/formats/plaintext.rs
@@ -1,5 +1,5 @@
-use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use std::fmt::{Display, Formatter};
 use std::io::BufRead;
 use thiserror::Error;
@@ -29,7 +29,8 @@ where
     }
     Ok(collector)
 }
-gen_scrape_froms!(scrape(Read)-> Result<Vec<TextFileLink>, TextFileScrapingError>);
+gen_scrape_from_file!(scrape(Read)-> Result<Vec<TextFileLink>, TextFileScrapingError>);
+gen_scrape_from_slice!(scrape(Read)-> Result<Vec<TextFileLink>, TextFileScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum TextFileScrapingError {

--- a/src/formats/plaintext.rs
+++ b/src/formats/plaintext.rs
@@ -1,22 +1,27 @@
-use std::fmt::{Display, Formatter};
-use std::io::{BufRead, BufReader};
-use thiserror::Error;
-use crate::gen_scrape_from_file;
+use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use std::fmt::{Display, Formatter};
+use std::io::BufRead;
+use thiserror::Error;
 
-pub fn scrape(bytes: &[u8]) -> Result<Vec<TextFileLink>, TextFileScrapingError> {
+pub fn scrape<R>(mut buf_reader: R) -> Result<Vec<TextFileLink>, TextFileScrapingError>
+where
+    R: BufRead,
+{
     let mut collector: Vec<TextFileLink> = vec![];
-    let mut buf_reader = BufReader::new(bytes);
     let mut contents = String::new();
     let mut line_result = buf_reader.read_line(&mut contents)?;
     let mut current_line = 1;
     while line_result > 0 {
-        find_urls(&contents)
-            .iter()
-            .for_each(|link| collector.push(TextFileLink {
+        find_urls(&contents).iter().for_each(|link| {
+            collector.push(TextFileLink {
                 url: link.as_str().to_string(),
-                location: TextFileLinkLocation { line: current_line, pos: link.start() }
-            }));
+                location: TextFileLinkLocation {
+                    line: current_line,
+                    pos: link.start(),
+                },
+            })
+        });
 
         contents.clear();
         line_result = buf_reader.read_line(&mut contents)?;
@@ -24,7 +29,7 @@ pub fn scrape(bytes: &[u8]) -> Result<Vec<TextFileLink>, TextFileScrapingError> 
     }
     Ok(collector)
 }
-gen_scrape_from_file!(Result<Vec<TextFileLink>, TextFileScrapingError>);
+gen_scrape_froms!(scrape(Read)-> Result<Vec<TextFileLink>, TextFileScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum TextFileScrapingError {
@@ -47,7 +52,7 @@ impl Display for TextFileLink {
 #[derive(Debug, Clone)]
 pub struct TextFileLinkLocation {
     pub line: usize,
-    pub pos: usize
+    pub pos: usize,
 }
 
 #[cfg(test)]
@@ -60,8 +65,12 @@ mod tests {
     fn scrape_test() {
         let links = scrape(TEST_XML).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://attribute.test.com"));
-        assert!(links.iter().any(|it| it.url == "https://plaintext.test.com"));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://attribute.test.com"));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://plaintext.test.com"));
         assert!(links.iter().any(|it| it.url == "https://comment.test.com"));
         assert!(links.iter().any(|it| it.url == "https://cdata.test.com"));
         assert!(links.iter().any(|it| it.url == "https://ns.test.com"));

--- a/src/formats/rtf.rs
+++ b/src/formats/rtf.rs
@@ -4,22 +4,16 @@ use itertools::Itertools;
 use rtf_parser::lexer::Lexer;
 use rtf_parser::tokens::Token;
 use std::fmt::{Display, Formatter};
-use std::io::{read_to_string, Read};
+use std::io::Read;
 use thiserror::Error;
 
 /// Limitations: Currently cannot extract Hyperlinks or comments.
 /// But you may use [`formats::plaintext::scrape`] for those.
-pub fn scrape<R>(reader: R) -> Result<Vec<RtfLink>, RtfScrapingError>
+pub fn scrape<T>(s: T) -> Result<Vec<RtfLink>, RtfScrapingError>
 where
-    R: Read,
+    T: AsRef<str>,
 {
-    scrape_from_string(&read_to_string(reader)?)
-}
-
-/// Limitations: Currently cannot extract Hyperlinks or comments.
-/// But you may use [`formats::plaintext::scrape`] for those.
-pub fn scrape_from_string(s: &str) -> Result<Vec<RtfLink>, RtfScrapingError> {
-    let tokens = Lexer::scan(s)?;
+    let tokens = Lexer::scan(s.as_ref())?;
     let mut text = String::new();
     tokens.iter().for_each(|token| {
         if let Token::PlainText(pt) = token {
@@ -35,10 +29,25 @@ pub fn scrape_from_string(s: &str) -> Result<Vec<RtfLink>, RtfScrapingError> {
         .collect_vec())
 }
 
-gen_scrape_froms!(scrape(Read) -> Result<Vec<RtfLink>, RtfScrapingError>);
+/// Limitations: Currently cannot extract Hyperlinks or comments.
+/// But you may use [`formats::plaintext::scrape`] for those.
+///
+/// Returns an error if `bytes` is not valid in UTF-8
+pub fn scrape_from_slice<T>(bytes: T) -> Result<Vec<RtfLink>, RtfScrapingError>
+where
+    T: AsRef<[u8]>,
+{
+    scrape(std::str::from_utf8(bytes.as_ref())?)
+}
+
+gen_scrape_froms!(
+    scrape_from_slice(AsRef<[u8]>, no_slice) -> Result<Vec<RtfLink>, RtfScrapingError>
+);
 
 #[derive(Error, Debug)]
 pub enum RtfScrapingError {
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]
@@ -65,7 +74,7 @@ mod tests {
     const TEST_RTF: &[u8] = include_bytes!("../../test_files/rtf/rtf_test.rtf");
     #[test]
     fn scrape_rtf_test() {
-        let links = scrape(TEST_RTF).unwrap();
+        let links = scrape_from_slice(TEST_RTF).unwrap();
         println!("{:?}", links);
         assert!(links
             .iter()

--- a/src/formats/rtf.rs
+++ b/src/formats/rtf.rs
@@ -54,9 +54,7 @@ where
     scrape_from_string(std::str::from_utf8(bytes.as_ref())?)
 }
 
-gen_scrape_froms!(
-    scrape_from_slice(AsRef<[u8]>, no_slice) -> Result<Vec<RtfLink>, RtfScrapingError>
-);
+gen_scrape_froms!(scrape_from_slice(AsRef<[u8]>) -> Result<Vec<RtfLink>, RtfScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum RtfScrapingError {

--- a/src/formats/rtf.rs
+++ b/src/formats/rtf.rs
@@ -1,4 +1,4 @@
-use crate::gen_scrape_froms;
+use crate::gen_scrape_from_file;
 use crate::helpers::find_urls;
 use itertools::Itertools;
 use rtf_parser::lexer::Lexer;
@@ -54,7 +54,7 @@ where
     scrape_from_string(std::str::from_utf8(bytes.as_ref())?)
 }
 
-gen_scrape_froms!(scrape_from_slice(AsRef<[u8]>) -> Result<Vec<RtfLink>, RtfScrapingError>);
+gen_scrape_from_file!(scrape_from_slice(AsRef<[u8]>) -> Result<Vec<RtfLink>, RtfScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum RtfScrapingError {

--- a/src/formats/xml/mod.rs
+++ b/src/formats/xml/mod.rs
@@ -1,5 +1,5 @@
-use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use std::fmt::{Display, Formatter};
 use std::io::Read;
 use thiserror::Error;
@@ -102,7 +102,8 @@ where
 
     Ok(collector)
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<XmlLink>, XmlScrapingError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<XmlLink>, XmlScrapingError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<XmlLink>, XmlScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum XmlScrapingError {

--- a/src/formats/xml/svg.rs
+++ b/src/formats/xml/svg.rs
@@ -1,6 +1,6 @@
 use crate::formats::xml::svg::SvgLinkKind::{Attribute, Comment, NameSpace, Script, Text};
 use crate::formats::xml::XmlLinkKind;
-use crate::gen_scrape_froms;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use std::fmt::{Display, Formatter};
 use std::io::Read;
 use thiserror::Error;
@@ -26,7 +26,8 @@ where
         })
         .collect())
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<SvgLink>, SvgScrapingError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<SvgLink>, SvgScrapingError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<SvgLink>, SvgScrapingError>);
 
 #[derive(Error, Debug)]
 pub enum SvgScrapingError {

--- a/src/formats/xml/xlink/elements.rs
+++ b/src/formats/xml/xlink/elements.rs
@@ -8,7 +8,7 @@ enum XLinkType {
     Locator,
     Arc,
     Resource,
-    Title
+    Title,
 }
 
 impl TryFrom<&str> for XLinkType {
@@ -22,7 +22,7 @@ impl TryFrom<&str> for XLinkType {
             "arc" => Ok(XLinkType::Arc),
             "resource" => Ok(XLinkType::Resource),
             "title" => Ok(XLinkType::Title),
-            _ => Err(XLinkFormatError::UnknownTypeError(value.to_string()))
+            _ => Err(XLinkFormatError::UnknownTypeError(value.to_string())),
         }
     }
 }
@@ -33,11 +33,13 @@ pub enum XlinkElement<'a> {
     Locator(XlinkLocatorElement<'a>),
     Arc(XlinkArcElement<'a>),
     Resource(XlinkResourceElement<'a>),
-    Title(XlinkTitleElement<'a>)
+    Title(XlinkTitleElement<'a>),
 }
 
 impl<'a> XlinkElement<'a> {
-    pub fn try_from_xml_start_element(xml_start_element: XmlStartElement<'a>) -> Result<Option<Self>, XLinkFormatError> {
+    pub fn try_from_xml_start_element(
+        xml_start_element: XmlStartElement<'a>,
+    ) -> Result<Option<Self>, XLinkFormatError> {
         let xlink_href = get_xlink_attribute_value("href", xml_start_element.attributes);
         let mut xlink_type_option = get_xlink_attribute_value("type", xml_start_element.attributes)
             .map(|type_value| XLinkType::try_from(type_value.as_str()))
@@ -45,19 +47,25 @@ impl<'a> XlinkElement<'a> {
         if xlink_href.is_some() && xlink_type_option.is_none() {
             xlink_type_option = Some(XLinkType::Simple);
         }
-        if xlink_type_option.is_none() { return Ok(None) }
+        if xlink_type_option.is_none() {
+            return Ok(None);
+        }
         match xlink_type_option {
             None => Ok(None),
-            Some(xlink_type) => {
-                match xlink_type {
-                    XLinkType::Simple => Ok(Some(XlinkElement::Simple(xml_start_element.try_into()?))),
-                    XLinkType::Extended => Ok(Some(XlinkElement::Extended(xml_start_element.try_into()?))),
-                    XLinkType::Locator => Ok(Some(XlinkElement::Locator(xml_start_element.try_into()?))),
-                    XLinkType::Arc => Ok(Some(XlinkElement::Arc(xml_start_element.try_into()?))),
-                    XLinkType::Resource => Ok(Some(XlinkElement::Resource(xml_start_element.try_into()?))),
-                    XLinkType::Title => Ok(Some(XlinkElement::Title(xml_start_element.try_into()?)))
+            Some(xlink_type) => match xlink_type {
+                XLinkType::Simple => Ok(Some(XlinkElement::Simple(xml_start_element.try_into()?))),
+                XLinkType::Extended => {
+                    Ok(Some(XlinkElement::Extended(xml_start_element.try_into()?)))
                 }
-            }
+                XLinkType::Locator => {
+                    Ok(Some(XlinkElement::Locator(xml_start_element.try_into()?)))
+                }
+                XLinkType::Arc => Ok(Some(XlinkElement::Arc(xml_start_element.try_into()?))),
+                XLinkType::Resource => {
+                    Ok(Some(XlinkElement::Resource(xml_start_element.try_into()?)))
+                }
+                XLinkType::Title => Ok(Some(XlinkElement::Title(xml_start_element.try_into()?))),
+            },
         }
     }
 }
@@ -69,7 +77,7 @@ pub struct XlinkSimpleElement<'a> {
     pub title: Option<String>,
     pub show: Option<String>,
     pub actuate: Option<String>,
-    pub xml: XmlStartElement<'a>
+    pub xml: XmlStartElement<'a>,
 }
 impl<'a> TryFrom<XmlStartElement<'a>> for XlinkSimpleElement<'a> {
     type Error = XLinkFormatError;
@@ -82,7 +90,7 @@ impl<'a> TryFrom<XmlStartElement<'a>> for XlinkSimpleElement<'a> {
             title: get_xlink_attribute_value("title", xml_start_element.attributes),
             show: get_xlink_attribute_value("show", xml_start_element.attributes),
             actuate: get_xlink_attribute_value("actuate", xml_start_element.attributes),
-            xml: xml_start_element
+            xml: xml_start_element,
         })
     }
 }
@@ -90,7 +98,7 @@ impl<'a> TryFrom<XmlStartElement<'a>> for XlinkSimpleElement<'a> {
 pub struct XlinkExtendedElement<'a> {
     pub role: Option<String>,
     pub title: Option<String>,
-    pub xml: XmlStartElement<'a>
+    pub xml: XmlStartElement<'a>,
 }
 impl<'a> TryFrom<XmlStartElement<'a>> for XlinkExtendedElement<'a> {
     type Error = XLinkFormatError;
@@ -99,7 +107,7 @@ impl<'a> TryFrom<XmlStartElement<'a>> for XlinkExtendedElement<'a> {
         Ok(XlinkExtendedElement {
             role: get_xlink_attribute_value("role", xml_start_element.attributes),
             title: get_xlink_attribute_value("title", xml_start_element.attributes),
-            xml: xml_start_element
+            xml: xml_start_element,
         })
     }
 }
@@ -108,18 +116,19 @@ pub struct XlinkLocatorElement<'a> {
     pub href: String,
     pub role: Option<String>,
     pub title: Option<String>,
-    pub xml: XmlStartElement<'a>
+    pub xml: XmlStartElement<'a>,
 }
 impl<'a> TryFrom<XmlStartElement<'a>> for XlinkLocatorElement<'a> {
     type Error = XLinkFormatError;
 
     fn try_from(xml_start_element: XmlStartElement<'a>) -> Result<Self, Self::Error> {
         Ok(XlinkLocatorElement {
-            href: get_xlink_attribute_value("href", xml_start_element.attributes)
-                .ok_or(XLinkFormatError::MissingRequiredAttributeError("href".to_string()))?,
+            href: get_xlink_attribute_value("href", xml_start_element.attributes).ok_or(
+                XLinkFormatError::MissingRequiredAttributeError("href".to_string()),
+            )?,
             role: get_xlink_attribute_value("role", xml_start_element.attributes),
             title: get_xlink_attribute_value("title", xml_start_element.attributes),
-            xml: xml_start_element
+            xml: xml_start_element,
         })
     }
 }
@@ -131,7 +140,7 @@ pub struct XlinkArcElement<'a> {
     pub actuate: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,
-    pub xml: XmlStartElement<'a>
+    pub xml: XmlStartElement<'a>,
 }
 impl<'a> TryFrom<XmlStartElement<'a>> for XlinkArcElement<'a> {
     type Error = XLinkFormatError;
@@ -144,7 +153,7 @@ impl<'a> TryFrom<XmlStartElement<'a>> for XlinkArcElement<'a> {
             actuate: get_xlink_attribute_value("actuate", xml_start_element.attributes),
             from: get_xlink_attribute_value("from", xml_start_element.attributes),
             to: get_xlink_attribute_value("to", xml_start_element.attributes),
-            xml: xml_start_element
+            xml: xml_start_element,
         })
     }
 }
@@ -153,7 +162,7 @@ pub struct XlinkResourceElement<'a> {
     pub role: Option<String>,
     pub title: Option<String>,
     pub label: Option<String>,
-    pub xml: XmlStartElement<'a>
+    pub xml: XmlStartElement<'a>,
 }
 impl<'a> TryFrom<XmlStartElement<'a>> for XlinkResourceElement<'a> {
     type Error = XLinkFormatError;
@@ -163,20 +172,20 @@ impl<'a> TryFrom<XmlStartElement<'a>> for XlinkResourceElement<'a> {
             role: get_xlink_attribute_value("role", xml_start_element.attributes),
             title: get_xlink_attribute_value("title", xml_start_element.attributes),
             label: get_xlink_attribute_value("label", xml_start_element.attributes),
-            xml: xml_start_element
+            xml: xml_start_element,
         })
     }
 }
 
 pub struct XlinkTitleElement<'a> {
-    pub xml: XmlStartElement<'a>
+    pub xml: XmlStartElement<'a>,
 }
 impl<'a> TryFrom<XmlStartElement<'a>> for XlinkTitleElement<'a> {
     type Error = XLinkFormatError;
 
     fn try_from(_xml_start_element: XmlStartElement<'a>) -> Result<Self, Self::Error> {
         Ok(XlinkTitleElement {
-            xml: _xml_start_element
+            xml: _xml_start_element,
         })
     }
 }

--- a/src/formats/xml/xlink/mod.rs
+++ b/src/formats/xml/xlink/mod.rs
@@ -8,8 +8,8 @@ use crate::formats::xml::xlink::XLinkFormatError::{
     ResourceOutsideOfExtendedError, SimpleInsideOfExtendedError,
 };
 use crate::formats::xml::XmlStartElement;
-use crate::gen_scrape_froms;
 use crate::helpers::find_urls;
+use crate::{gen_scrape_from_file, gen_scrape_from_slice};
 use itertools::Itertools;
 use std::io::Read;
 use thiserror::Error;
@@ -49,7 +49,8 @@ where
 
     Ok(collector)
 }
-gen_scrape_froms!(scrape(Read) -> Result<Vec<XLinkLink>, XLinkFormatError>);
+gen_scrape_from_file!(scrape(Read) -> Result<Vec<XLinkLink>, XLinkFormatError>);
+gen_scrape_from_slice!(scrape(Read) -> Result<Vec<XLinkLink>, XLinkFormatError>);
 
 #[derive(Error, Debug)]
 pub enum XLinkFormatError {

--- a/src/formats/xml/xlink/mod.rs
+++ b/src/formats/xml/xlink/mod.rs
@@ -1,25 +1,45 @@
 pub mod elements;
 
+use crate::formats::xml::xlink::elements::{
+    XlinkElement, XlinkExtendedElement, XlinkSimpleElement,
+};
+use crate::formats::xml::xlink::XLinkFormatError::{
+    ArcOutsideOfExtendedError, ExtendedInsideOfExtendedError, LocatorOutsideOfExtendedError,
+    ResourceOutsideOfExtendedError, SimpleInsideOfExtendedError,
+};
+use crate::formats::xml::XmlStartElement;
+use crate::gen_scrape_froms;
+use crate::helpers::find_urls;
 use itertools::Itertools;
+use std::io::Read;
 use thiserror::Error;
 use xml::attribute::OwnedAttribute;
 use xml::common::{Position, TextPosition};
-use xml::EventReader;
 use xml::reader::XmlEvent;
-use crate::formats::xml::xlink::elements::{XlinkElement, XlinkExtendedElement, XlinkSimpleElement};
-use crate::formats::xml::xlink::XLinkFormatError::{ArcOutsideOfExtendedError, ExtendedInsideOfExtendedError, LocatorOutsideOfExtendedError, ResourceOutsideOfExtendedError, SimpleInsideOfExtendedError};
-use crate::formats::xml::XmlStartElement;
-use crate::gen_scrape_from_file;
-use crate::helpers::find_urls;
+use xml::EventReader;
 
-pub fn scrape(bytes: &[u8]) -> Result<Vec<XLinkLink>, XLinkFormatError> {
+pub fn scrape<R>(reader: R) -> Result<Vec<XLinkLink>, XLinkFormatError>
+where
+    R: Read,
+{
     let mut collector: Vec<XLinkLink> = vec![];
 
-    let mut parser = EventReader::new(bytes);
+    let mut parser = EventReader::new(reader);
     while let Ok(xml_event) = &parser.next() {
         match xml_event {
-            XmlEvent::StartElement { name, attributes, namespace } => {
-                let mut list = scrape_from_start_element(XmlStartElement { name, attributes, _namespace: namespace }, &mut parser)?;
+            XmlEvent::StartElement {
+                name,
+                attributes,
+                namespace,
+            } => {
+                let mut list = scrape_from_start_element(
+                    XmlStartElement {
+                        name,
+                        attributes,
+                        _namespace: namespace,
+                    },
+                    &mut parser,
+                )?;
                 collector.append(&mut list)
             }
             XmlEvent::EndDocument => break,
@@ -29,7 +49,7 @@ pub fn scrape(bytes: &[u8]) -> Result<Vec<XLinkLink>, XLinkFormatError> {
 
     Ok(collector)
 }
-gen_scrape_from_file!(Result<Vec<XLinkLink>, XLinkFormatError>);
+gen_scrape_froms!(scrape(Read) -> Result<Vec<XLinkLink>, XLinkFormatError>);
 
 #[derive(Error, Debug)]
 pub enum XLinkFormatError {
@@ -50,13 +70,16 @@ pub enum XLinkFormatError {
     #[error("Found a extended-element inside of an extended element.")]
     ExtendedInsideOfExtendedError,
     #[error(transparent)]
-    XmlReaderError(#[from] xml::reader::Error)
+    XmlReaderError(#[from] xml::reader::Error),
 }
 
 fn get_xlink_attribute_value(key: &str, attributes: &Vec<OwnedAttribute>) -> Option<String> {
-    attributes.iter()
-        .find( |attribute|
-            attribute.name.local_name == key && attribute.name.namespace == Some(XLINK_NAMESPACE.to_string()))
+    attributes
+        .iter()
+        .find(|attribute| {
+            attribute.name.local_name == key
+                && attribute.name.namespace == Some(XLINK_NAMESPACE.to_string())
+        })
         .map(|href_attribute| href_attribute.value.to_string())
 }
 
@@ -64,7 +87,7 @@ fn get_xlink_attribute_value(key: &str, attributes: &Vec<OwnedAttribute>) -> Opt
 pub struct XLinkLink {
     pub url: String,
     pub location: TextPosition,
-    pub kind: XLinkLinkKind
+    pub kind: XLinkLinkKind,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -77,9 +100,16 @@ pub enum XLinkLinkKind {
 
 static XLINK_NAMESPACE: &str = "http://www.w3.org/1999/xlink";
 
-fn scrape_from_start_element(xml_start_element: XmlStartElement, mut parser: &mut EventReader<&[u8]>) -> Result<Vec<XLinkLink>, XLinkFormatError> {
-    let Some(xlink_element) = XlinkElement::try_from_xml_start_element(xml_start_element)?
-    else { return Ok(vec![]) };
+fn scrape_from_start_element<R>(
+    xml_start_element: XmlStartElement,
+    mut parser: &mut EventReader<R>,
+) -> Result<Vec<XLinkLink>, XLinkFormatError>
+where
+    R: Read,
+{
+    let Some(xlink_element) = XlinkElement::try_from_xml_start_element(xml_start_element)? else {
+        return Ok(vec![]);
+    };
 
     match xlink_element {
         XlinkElement::Simple(element) => Ok(scrape_from_xlink_simple(element, &parser)),
@@ -87,62 +117,97 @@ fn scrape_from_start_element(xml_start_element: XmlStartElement, mut parser: &mu
         XlinkElement::Locator(_) => Err(LocatorOutsideOfExtendedError),
         XlinkElement::Arc(_) => Err(ArcOutsideOfExtendedError),
         XlinkElement::Resource(_) => Err(ResourceOutsideOfExtendedError),
-        XlinkElement::Title(_) => Ok(vec![])
+        XlinkElement::Title(_) => Ok(vec![]),
     }
 }
 
-fn scrape_from_option_string(role: Option<String>, link_type: XLinkLinkKind, position: TextPosition) -> Vec<XLinkLink> {
-    let Some(role) = role
-        else { return vec![] };
-    let links = find_urls(&role).iter()
+fn scrape_from_option_string(
+    role: Option<String>,
+    link_type: XLinkLinkKind,
+    position: TextPosition,
+) -> Vec<XLinkLink> {
+    let Some(role) = role else { return vec![] };
+    let links = find_urls(&role)
+        .iter()
         .map(|link| XLinkLink {
             url: link.as_str().to_string(),
             location: position,
             kind: link_type,
-        }).collect_vec();
+        })
+        .collect_vec();
     links
 }
 
-fn scrape_from_xlink_extended(xlink_extended_element: XlinkExtendedElement, parser: &mut EventReader<&[u8]>) -> Result<Vec<XLinkLink>, XLinkFormatError> {
-    let mut ret: Vec<XLinkLink> = scrape_from_option_string(xlink_extended_element.role, XLinkLinkKind::Role, parser.position());
+fn scrape_from_xlink_extended<R>(
+    xlink_extended_element: XlinkExtendedElement,
+    parser: &mut EventReader<R>,
+) -> Result<Vec<XLinkLink>, XLinkFormatError>
+where
+    R: Read,
+{
+    let mut ret: Vec<XLinkLink> = scrape_from_option_string(
+        xlink_extended_element.role,
+        XLinkLinkKind::Role,
+        parser.position(),
+    );
 
     while let Ok(xml_event) = &parser.next() {
         let mut links = match xml_event {
-            XmlEvent::StartElement { name, attributes, namespace } => {
-                let Some(xlink_element) = 
-                    XlinkElement::try_from_xml_start_element(XmlStartElement{ name, attributes, _namespace: namespace })?
-                else { continue };
-                
+            XmlEvent::StartElement {
+                name,
+                attributes,
+                namespace,
+            } => {
+                let Some(xlink_element) =
+                    XlinkElement::try_from_xml_start_element(XmlStartElement {
+                        name,
+                        attributes,
+                        _namespace: namespace,
+                    })?
+                else {
+                    continue;
+                };
+
                 match xlink_element {
                     XlinkElement::Simple(_) => Err(SimpleInsideOfExtendedError),
                     XlinkElement::Extended(_) => Err(ExtendedInsideOfExtendedError),
                     XlinkElement::Locator(element) => {
                         let mut locator_links = vec![];
-                        
+
                         locator_links.push(XLinkLink {
                             url: element.href,
                             location: parser.position(),
-                            kind: XLinkLinkKind::Extended
+                            kind: XLinkLinkKind::Extended,
                         });
-                        locator_links.append(&mut scrape_from_option_string(element.role, XLinkLinkKind::Role, parser.position()));
-                        
+                        locator_links.append(&mut scrape_from_option_string(
+                            element.role,
+                            XLinkLinkKind::Role,
+                            parser.position(),
+                        ));
+
                         Ok(locator_links)
                     }
-                    XlinkElement::Arc(element) => {
-                        Ok(scrape_from_option_string(element.arcrole, XLinkLinkKind::ArcRole, parser.position()))
-                    },
-                    XlinkElement::Resource(element) => {
-                        Ok(scrape_from_option_string(element.role, XLinkLinkKind::Role, parser.position()))
-                    },
-                    XlinkElement::Title(_) => Ok(vec![])
+                    XlinkElement::Arc(element) => Ok(scrape_from_option_string(
+                        element.arcrole,
+                        XLinkLinkKind::ArcRole,
+                        parser.position(),
+                    )),
+                    XlinkElement::Resource(element) => Ok(scrape_from_option_string(
+                        element.role,
+                        XLinkLinkKind::Role,
+                        parser.position(),
+                    )),
+                    XlinkElement::Title(_) => Ok(vec![]),
                 }?
             }
             XmlEvent::EndElement { name } => {
                 if name.eq(xlink_extended_element.xml.name) {
-                    break
-                } else { vec![] }
+                    break;
+                } else {
+                    vec![]
+                }
             }
-            _ => vec![]
+            _ => vec![],
         };
         ret.append(&mut links);
     }
@@ -150,10 +215,25 @@ fn scrape_from_xlink_extended(xlink_extended_element: XlinkExtendedElement, pars
     Ok(ret)
 }
 
-fn scrape_from_xlink_simple(xlink_element: XlinkSimpleElement, parser: &EventReader<&[u8]>) -> Vec<XLinkLink> {
-    let mut ret = scrape_from_option_string(xlink_element.href, XLinkLinkKind::Simple, parser.position());
-    ret.append(&mut scrape_from_option_string(xlink_element.arcrole, XLinkLinkKind::ArcRole, parser.position()));
-    ret.append(&mut scrape_from_option_string(xlink_element.role, XLinkLinkKind::Role, parser.position()));
+fn scrape_from_xlink_simple<R>(
+    xlink_element: XlinkSimpleElement,
+    parser: &EventReader<R>,
+) -> Vec<XLinkLink>
+where
+    R: Read,
+{
+    let mut ret =
+        scrape_from_option_string(xlink_element.href, XLinkLinkKind::Simple, parser.position());
+    ret.append(&mut scrape_from_option_string(
+        xlink_element.arcrole,
+        XLinkLinkKind::ArcRole,
+        parser.position(),
+    ));
+    ret.append(&mut scrape_from_option_string(
+        xlink_element.role,
+        XLinkLinkKind::Role,
+        parser.position(),
+    ));
     ret
 }
 
@@ -167,8 +247,17 @@ mod tests {
     fn scrape_xlink_test() {
         let links = scrape(TEST_XLINK).unwrap();
         println!("{:?}", links);
-        assert!(links.iter().any(|it| it.url == "https://simple.test.com" && it.kind == XLinkLinkKind::Simple));
-        assert!(links.iter().any(|it| it.url == "https://extended.test.com/" && it.kind == XLinkLinkKind::Extended));
-        assert!(links.iter().any(|it| it.url == "https://role.test.com/" && it.kind == XLinkLinkKind::Role));
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://simple.test.com" && it.kind == XLinkLinkKind::Simple));
+        assert!(
+            links
+                .iter()
+                .any(|it| it.url == "https://extended.test.com/"
+                    && it.kind == XLinkLinkKind::Extended)
+        );
+        assert!(links
+            .iter()
+            .any(|it| it.url == "https://role.test.com/" && it.kind == XLinkLinkKind::Role));
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -33,32 +33,6 @@ macro_rules! gen_scrape_froms {
                 f.read_to_end(&mut buffer)?;
                 buffer
             };
-            scrape_from_slice(bytes)
-        }
-
-        /// Convenience function, that uses [`scrape`] to scrape links from a buffer.
-        #[inline(always)]
-        pub fn scrape_from_slice<T>(buffer: T) -> $output_type
-        where
-            T: AsRef<[u8]>,
-        {
-            $function_name(buffer)
-        }
-    };
-
-    ($function_name:ident(AsRef<[u8]>, no_slice) -> $output_type:ty) => {
-        /// Convenience function, that reads a file and uses [`scrape`] to scrape links from its content.
-        pub fn scrape_from_file<P>(path: P) -> $output_type
-        where
-            P: AsRef<std::path::Path>,
-        {
-            let bytes: Vec<u8> = {
-                let mut f = std::fs::File::open(&path)?;
-                let metadata = std::fs::metadata(path)?;
-                let mut buffer = Vec::with_capacity(metadata.len() as usize);
-                f.read_to_end(&mut buffer)?;
-                buffer
-            };
             $function_name(bytes)
         }
     };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -19,7 +19,20 @@ pub fn find_urls(content: &str) -> Vec<linkify::Link> {
 }
 
 #[macro_export]
-macro_rules! gen_scrape_froms {
+macro_rules! gen_scrape_from_slice {
+    ($function_name:ident(Read) -> $output_type:ty) => {
+        /// Convenience function, that uses [`scrape`] to scrape links from a buffer.
+        pub fn scrape_from_slice<T>(buffer: T) -> $output_type
+        where
+            T: AsRef<[u8]>,
+        {
+            $function_name(std::io::Cursor::new(buffer.as_ref()))
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! gen_scrape_from_file {
     ($function_name:ident(AsRef<[u8]>) -> $output_type:ty) => {
         /// Convenience function, that reads a file and uses [`scrape`] to scrape links from its content.
         pub fn scrape_from_file<P>(path: P) -> $output_type
@@ -44,14 +57,6 @@ macro_rules! gen_scrape_froms {
             P: AsRef<std::path::Path>,
         {
             $function_name(std::io::BufReader::new(std::fs::File::open(path)?))
-        }
-
-        /// Convenience function, that uses [`scrape`] to scrape links from a buffer.
-        pub fn scrape_from_slice<T>(buffer: T) -> $output_type
-        where
-            T: AsRef<[u8]>,
-        {
-            $function_name(std::io::Cursor::new(buffer.as_ref()))
         }
     };
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -27,13 +27,13 @@ macro_rules! gen_scrape_froms {
             P: AsRef<std::path::Path>,
         {
             let bytes: Vec<u8> = {
-                let mut f = std::fs::File::open(path)?;
+                let mut f = std::fs::File::open(&path)?;
                 let metadata = std::fs::metadata(path)?;
                 let mut buffer = Vec::with_capacity(metadata.len() as usize);
                 f.read_to_end(&mut buffer)?;
                 buffer
             };
-            $function_name(bytes)
+            scrape_from_slice(bytes)
         }
 
         /// Convenience function, that uses [`scrape`] to scrape links from a buffer.
@@ -43,6 +43,23 @@ macro_rules! gen_scrape_froms {
             T: AsRef<[u8]>,
         {
             $function_name(buffer)
+        }
+    };
+
+    ($function_name:ident(AsRef<[u8]>, no_slice) -> $output_type:ty) => {
+        /// Convenience function, that reads a file and uses [`scrape`] to scrape links from its content.
+        pub fn scrape_from_file<P>(path: P) -> $output_type
+        where
+            P: AsRef<std::path::Path>,
+        {
+            let bytes: Vec<u8> = {
+                let mut f = std::fs::File::open(&path)?;
+                let metadata = std::fs::metadata(path)?;
+                let mut buffer = Vec::with_capacity(metadata.len() as usize);
+                f.read_to_end(&mut buffer)?;
+                buffer
+            };
+            $function_name(bytes)
         }
     };
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -12,29 +12,55 @@ pub use crate::any_format_scraper::scrape;
 /// assert_eq!(urls.first().unwrap().as_str(), "https://www.google.com")
 /// ```
 pub fn find_urls(content: &str) -> Vec<linkify::Link> {
-    LinkFinder::new().links(content)
+    LinkFinder::new()
+        .links(content)
         .filter(|link| link.kind().eq(&Url))
         .collect()
 }
 
-#[macro_export] macro_rules! gen_scrape_from_file {
-    ($output_type:ty) => {
-        use std::fs::File;
-        use std::io::Read;
-        use std::path::Path;
-        use std::fs;
-
+#[macro_export]
+macro_rules! gen_scrape_froms {
+    ($function_name:ident(AsRef<[u8]>) -> $output_type:ty) => {
         /// Convenience function, that reads a file and uses [`scrape`] to scrape links from its content.
-        pub fn scrape_from_file(path: &Path) -> $output_type {
+        pub fn scrape_from_file<P>(path: P) -> $output_type
+        where
+            P: AsRef<std::path::Path>,
+        {
             let bytes: Vec<u8> = {
-                let mut f = File::open(path)?;
-                let metadata = fs::metadata(path)?;
-                let mut buffer = vec![0; metadata.len() as usize];
-                f.read(&mut buffer).expect("buffer overflow");
-
+                let mut f = std::fs::File::open(path)?;
+                let metadata = std::fs::metadata(path)?;
+                let mut buffer = Vec::with_capacity(metadata.len() as usize);
+                f.read_to_end(&mut buffer)?;
                 buffer
             };
-            scrape(&bytes)
+            $function_name(bytes)
         }
-    }
+
+        /// Convenience function, that uses [`scrape`] to scrape links from a buffer.
+        #[inline(always)]
+        pub fn scrape_from_slice<T>(buffer: T) -> $output_type
+        where
+            T: AsRef<[u8]>,
+        {
+            $function_name(buffer)
+        }
+    };
+
+    ($function_name:ident(Read) -> $output_type:ty) => {
+        /// Convenience function, that reads a file and uses [`scrape`] to scrape links from its content.
+        pub fn scrape_from_file<P>(path: P) -> $output_type
+        where
+            P: AsRef<std::path::Path>,
+        {
+            $function_name(std::io::BufReader::new(std::fs::File::open(path)?))
+        }
+
+        /// Convenience function, that uses [`scrape`] to scrape links from a buffer.
+        pub fn scrape_from_slice<T>(buffer: T) -> $output_type
+        where
+            T: AsRef<[u8]>,
+        {
+            $function_name(std::io::Cursor::new(buffer.as_ref()))
+        }
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@
 //!
 //! Please refer to the git-projects README.md for known issues and further information.
 
-/// Helper functions
-pub mod helpers;
-/// Contains format-specific scrape-functions. Prefer over [`any_format_scraper`].
-pub mod formats;
 #[cfg(feature = "any_format")]
 /// Use only if you're not sure what format your file will be.
 pub mod any_format_scraper;
+/// Contains format-specific scrape-functions. Prefer over [`any_format_scraper`].
+pub mod formats;
+/// Helper functions
+pub mod helpers;


### PR DESCRIPTION
Hello Lukas,

I made some improvements for your lib that proved useful for Atra. 

Here a short list:
- Improve the memory usage for: ooxml, odf, image, xml, svg, xlink by using appropiate types. (Usually by avoiding to load the whole file at once.)
- Changed the interface from explicit `&[u8]` to `impl AsRef<[u8]>` when appropiate.
- Improved the for scraping rdf files.
- Generalize the processing of odf and ooxml documents by making the read process more generic.
- Improve memory usage of any_format when guessing types.
- Add some mime expressions for ooxml in any_format.
- Executed rustfmt on the whole codebase because I didn't want to bother with formatting all my changes.
- Improved `use` hygiene in the macros.

The only problem is that I wasn't able to test the `pdf` changes because I'm on a windows system. So before accepting the PR you should run the tests with the pdf feature on linux if possible.

Best regards
Felix